### PR TITLE
Fix DEBUG logic across projects

### DIFF
--- a/backend/settings.py
+++ b/backend/settings.py
@@ -23,7 +23,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = os.environ.get('DEBUG').upper() == "TRUE"
+DEBUG = bool(os.environ.get('DEBUG', False))
 
 ALLOWED_HOSTS = ['*']
 


### PR DESCRIPTION
Setting DEBUG off in Production across projects:
https://github.com/hackoregon/civic-devops/issues/139

And using the technique suggested by Hassan to set it cleanly:
https://github.com/hackoregon/neighborhoods-2018/pull/27/files/69f27184cd6cf2a994be072b1f5482d136a5fd96

The only change to local development that should be necessary is to ensure all developers have `DEBUG = True` in their environment variables (or `.env` file, or however they're managing environment).