### PR TITLE
Add smoke test

### DIFF
--- a/api/tests/tests.py
+++ b/api/tests/tests.py
@@ -1,5 +1,6 @@
 from django.test import TestCase, SimpleTestCase, TransactionTestCase
 from api.models import preexisting_models
+from rest_framework.test import APIClient, RequestsClient
 
 
 # Django, Writing and Running Unit Tests: https://docs.djangoproject.com/en/2.0/topics/testing/overview/
@@ -29,3 +30,9 @@ class ExampleSimpleTestCase(SimpleTestCase):
 class ExampleTransactionTestCase(TransactionTestCase):
     def test_transaction_example(self):
         self.assertTrue(True)
+class RootEndpointsTestCase(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+    def test_list_200_response(self):
+        response = self.client.get('/disaster-resilience/')
+        assert response.status_code == 200


### PR DESCRIPTION
Adding smoke test per [civic-devops issue 150](https://github.com/hackoregon/civic-devops/issues/150) to prevent non-functioning Django from deploying.

Could further use some smoke tests to verify that each endpoint is responding, but since they are currently 404'ing, no point in setting us up to fail.