### PR TITLE
Remove TransactionTestCase

### DIFF
--- a/api/tests/tests.py
+++ b/api/tests/tests.py
@@ -26,10 +26,6 @@ class ExampleSimpleTestCase(SimpleTestCase):
     def test_simple_example(self):
         self.assertTrue(True)
 
-# https://docs.djangoproject.com/en/2.0/topics/testing/tools/#transactiontestcase
-class ExampleTransactionTestCase(TransactionTestCase):
-    def test_transaction_example(self):
-        self.assertTrue(True)
 class RootEndpointsTestCase(TestCase):
     def setUp(self):
         self.client = APIClient()


### PR DESCRIPTION
Attempts to reset database, which would require write access to the DB.  Unnecessary and in fact dangerous.

Moss reported errors in a recent Travis build:

```
django.db.utils.IntegrityError: insert or update on table "auth_permission" violates foreign key constraint "auth_permission_content_type_id_2f476e4b_fk_django_co"
E               DETAIL:  Key (content_type_id)=(1980) is not present in table "django_content_type".
```

Brian Grant reported on some research into this error:

> looking at the documentation for the one that is causing the error: TransactionTestCase, it specifically states it includes this functionality:

```Resetting the database to a known state at the beginning of each test to ease testing and using the ORM.
Database fixtures.
Test skipping based on database backend features.
The remaining specialized assert* methods.```

> so seems to automatically want write access to the db, so i would expect would fail. preferable solution is to write some valid tests for the api code itself